### PR TITLE
Add message collapse feature

### DIFF
--- a/src/renderer/src/databases/index.ts
+++ b/src/renderer/src/databases/index.ts
@@ -3,7 +3,7 @@ import { FileMetadata, KnowledgeItem, QuickPhrase, TranslateHistory } from '@ren
 import type { Message as NewMessage, MessageBlock } from '@renderer/types/newMessage'
 import { Dexie, type EntityTable } from 'dexie'
 
-import { upgradeToV5, upgradeToV7 } from './upgrades'
+import { upgradeToV5, upgradeToV7, upgradeToV8 } from './upgrades'
 
 // Database declaration (move this to its own module also)
 export const db = new Dexie('CherryStudio') as Dexie & {
@@ -73,5 +73,17 @@ db.version(7)
     message_blocks: 'id, messageId, file.id' // Correct syntax with comma separator
   })
   .upgrade((tx) => upgradeToV7(tx))
+
+db.version(8)
+  .stores({
+    files: 'id, name, origin_name, path, size, ext, type, created_at, count',
+    topics: '&id',
+    settings: '&id, value',
+    knowledge_notes: '&id, baseId, type, content, created_at, updated_at',
+    translate_history: '&id, sourceText, targetText, sourceLanguage, targetLanguage, createdAt',
+    quick_phrases: 'id',
+    message_blocks: 'id, messageId, file.id'
+  })
+  .upgrade((tx) => upgradeToV8(tx))
 
 export default db

--- a/src/renderer/src/databases/upgrades.ts
+++ b/src/renderer/src/databases/upgrades.ts
@@ -308,3 +308,22 @@ export async function upgradeToV7(tx: Transaction): Promise<void> {
 
   Logger.log('DB migration to version 7 finished successfully.')
 }
+
+export async function upgradeToV8(tx: Transaction): Promise<void> {
+  const topics = await tx.table('topics').toArray()
+
+  for (const topic of topics) {
+    let updated = false
+    if (Array.isArray(topic.messages)) {
+      for (const message of topic.messages) {
+        if (message && message.collapsed === undefined) {
+          message.collapsed = false
+          updated = true
+        }
+      }
+    }
+    if (updated) {
+      await tx.table('topics').put(topic)
+    }
+  }
+}

--- a/src/renderer/src/pages/home/Messages/Message.tsx
+++ b/src/renderer/src/pages/home/Messages/Message.tsx
@@ -153,42 +153,40 @@ const MessageItem: FC<Props> = ({
           onCancel={handleEditCancel}
         />
       )}
-      {!isEditing && (
-        <>
-          <MessageContentContainer
-            className={
-              message.role === 'user'
-                ? 'message-content-container message-content-container-user'
-                : message.role === 'assistant'
-                  ? 'message-content-container message-content-container-assistant'
-                  : 'message-content-container'
-            }
-            style={{
-              fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
-              fontSize,
-              overflowY: 'visible'
-            }}>
-            <MessageErrorBoundary>
-              <MessageContent message={message} />
-            </MessageErrorBoundary>
-          </MessageContentContainer>
-          {showMenubar && (
-            <MessageFooter className="MessageFooter">
-              <MessageMenubar
-                message={message}
-                assistant={assistant}
-                model={model}
-                index={index}
-                topic={topic}
-                isLastMessage={isLastMessage}
-                isAssistantMessage={isAssistantMessage}
-                isGrouped={isGrouped}
-                messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
-                setModel={setModel}
-              />
-            </MessageFooter>
-          )}
-        </>
+      {!isEditing && !message.collapsed && (
+        <MessageContentContainer
+          className={
+            message.role === 'user'
+              ? 'message-content-container message-content-container-user'
+              : message.role === 'assistant'
+                ? 'message-content-container message-content-container-assistant'
+                : 'message-content-container'
+          }
+          style={{
+            fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
+            fontSize,
+            overflowY: 'visible'
+          }}>
+          <MessageErrorBoundary>
+            <MessageContent message={message} />
+          </MessageErrorBoundary>
+        </MessageContentContainer>
+      )}
+      {!isEditing && showMenubar && (
+        <MessageFooter className="MessageFooter">
+          <MessageMenubar
+            message={message}
+            assistant={assistant}
+            model={model}
+            index={index}
+            topic={topic}
+            isLastMessage={isLastMessage}
+            isAssistantMessage={isAssistantMessage}
+            isGrouped={isGrouped}
+            messageContainerRef={messageContainerRef as React.RefObject<HTMLDivElement>}
+            setModel={setModel}
+          />
+        </MessageFooter>
       )}
     </MessageContainer>
   )

--- a/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
+++ b/src/renderer/src/pages/home/Messages/MessageMenubar.tsx
@@ -11,6 +11,8 @@ import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { getMessageTitle } from '@renderer/services/MessagesService'
 import { translateText } from '@renderer/services/TranslateService'
 import store, { RootState } from '@renderer/store'
+import { useAppDispatch } from '@renderer/store'
+import { newMessagesActions } from '@renderer/store/newMessage'
 import { messageBlocksSelectors } from '@renderer/store/messageBlock'
 import { selectMessagesForTopic } from '@renderer/store/newMessage'
 import type { Assistant, Model, Topic } from '@renderer/types'
@@ -42,7 +44,9 @@ import {
   Share,
   Split,
   ThumbsUp,
-  Trash
+  Trash,
+  ChevronDown,
+  ChevronUp
 } from 'lucide-react'
 import { FC, memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -71,6 +75,7 @@ const MessageMenubar: FC<Props> = (props) => {
   const [isTranslating, setIsTranslating] = useState(false)
   const [showRegenerateTooltip, setShowRegenerateTooltip] = useState(false)
   const [showDeleteTooltip, setShowDeleteTooltip] = useState(false)
+  const dispatch = useAppDispatch()
   // const assistantModel = assistant?.model
   const {
     editMessage,
@@ -390,6 +395,17 @@ const MessageMenubar: FC<Props> = (props) => {
     [message, editMessage]
   )
 
+  const onToggleCollapse = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      dispatch(newMessagesActions.setMessageCollapsed({
+        messageId: message.id,
+        collapsed: !message.collapsed
+      }))
+    },
+    [dispatch, message]
+  )
+
   const blockEntities = useSelector(messageBlocksSelectors.selectEntities)
   const hasTranslationBlocks = useMemo(() => {
     const translationBlocks = findTranslationBlocks(message)
@@ -534,6 +550,13 @@ const MessageMenubar: FC<Props> = (props) => {
           </ActionButton>
         </Tooltip>
       )}
+      <Tooltip
+        title={message.collapsed ? t('common.expand') : t('common.collapse')}
+        mouseEnterDelay={0.8}>
+        <ActionButton className="message-action-button" onClick={onToggleCollapse} $softHoverBg={softHoverBg}>
+          {message.collapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+        </ActionButton>
+      </Tooltip>
       <Popconfirm
         title={t('message.message.delete.content')}
         okButtonProps={{ danger: true }}

--- a/src/renderer/src/store/newMessage.ts
+++ b/src/renderer/src/store/newMessage.ts
@@ -116,6 +116,13 @@ const messagesSlice = createSlice({
         state.loadingByTopic[topicId] = false
       }
     },
+    setMessageCollapsed(state, action: PayloadAction<{ messageId: string; collapsed: boolean }>) {
+      const { messageId, collapsed } = action.payload
+      const message = state.entities[messageId]
+      if (message) {
+        messagesAdapter.updateOne(state, { id: messageId, changes: { collapsed } })
+      }
+    },
     updateMessage(
       state,
       action: PayloadAction<{

--- a/src/renderer/src/types/newMessage.ts
+++ b/src/renderer/src/types/newMessage.ts
@@ -184,6 +184,7 @@ export type Message = {
   // UI相关
   multiModelMessageStyle?: 'horizontal' | 'vertical' | 'fold' | 'grid'
   foldSelected?: boolean
+  collapsed?: boolean
 
   // 块集合
   blocks: MessageBlock['id'][]


### PR DESCRIPTION
## Summary
- extend message type with `collapsed` option
- add `setMessageCollapsed` reducer
- hide message content when collapsed and add toggle in menubar
- store collapse state in Dexie (DB version 8)

## Testing
- `yarn test` *(fails: request to repo.yarnpkg.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68680dea96d8832688a95036f8b2d4f7